### PR TITLE
Advanced calibration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ An async and no_std rust library for the wide-bandwidth haptic driver IC DA7280/
 - Reading and clearing system events and diagnostics
 - Driving an LRA in frequency track, wideband or custom waveform mode
 - DRO mode
+- Uploading into the waveform memory and RTWM_MODE
 
 ## What's missing
 - Testing of PWM_MODE
-- Uploading into the waveform memory and RTWM_MODE
 - GPI configuration and ETWM_MODE
 - Uploading a script (list of registers and values as exported by GUI)
 
@@ -49,7 +49,10 @@ An async and no_std rust library for the wide-bandwidth haptic driver IC DA7280/
         absolute_max_mV: 2_260,
         max_current_mA: 165,
         impedance_mOhm: 13_800,
+        inductance_uH: 50,
         frequency_Hz: 170,
+        pid_Ki: None,
+        pid_Kp: None
     };
 
     // DRO Mode, which means we can set the amplitude via set_override_value()

--- a/examples/nrf54l15/src/main.rs
+++ b/examples/nrf54l15/src/main.rs
@@ -45,7 +45,10 @@ async fn main(_spawner: Spawner) {
         absolute_max_mV: 2_260,
         max_current_mA: 165,
         impedance_mOhm: 13_800,
+        inductance_uH: 50, // Just a guess
         frequency_Hz: 170,
+        pid_Ki: None,
+        pid_Kp: None
     };
 
     let device_config = DeviceConfig {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,5 @@
+use core::option::Option;
+
 #[allow(non_snake_case)]
 #[derive(Debug, Clone, Copy)]
 pub struct ActuatorConfig
@@ -7,7 +9,10 @@ pub struct ActuatorConfig
     pub absolute_max_mV: u16, 
     pub max_current_mA: u16,
     pub impedance_mOhm: u16,
-    pub frequency_Hz: u16
+    pub inductance_uH: u16,
+    pub frequency_Hz: u16,
+    pub pid_Kp: Option<u16>,
+    pub pid_Ki: Option<u16> 
 }
 
 #[allow(nonstandard_style)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,11 @@ use crate::registers::SEQ_CTL2;
 use crate::registers::TOP_CFG2;
 use crate::registers::TOP_CFG4;
 use crate::registers::TOP_CTL2;
+use crate::registers::TOP_INT_CFG6_H;
+use crate::registers::TOP_INT_CFG6_L;
+use crate::registers::TOP_INT_CFG7_H;
+use crate::registers::TOP_INT_CFG7_L;
+use crate::registers::TRIM4;
 use crate::waveform::WaveformMemory;
 
 pub enum Variant {
@@ -177,8 +182,7 @@ where
         let actuator1 = ACTUATOR1::from(volt_converted);
         self.write_register(Register::ACTUATOR1, actuator1.into()).await?;
 
-
-        // ACTUATOR2 (as max volt)
+        // ACTUATOR2 (abs max volt)
         let volt_converted = ((actuator_config.absolute_max_mV as u32 * 1000) / 23400) as u8; // +1?
         let actuator2 = ACTUATOR2::from(volt_converted);
         self.write_register(Register::ACTUATOR2, actuator2.into()).await?;
@@ -196,6 +200,68 @@ where
         let calib_v2i_l = CALIB_V2I_L::from(bytes[1]);
         self.write_register(Register::CALIB_V2I_H, calib_v2i_h.into()).await?;
         self.write_register(Register::CALIB_V2I_L, calib_v2i_l.into()).await?;
+
+        // Setting TRIM4: LOOP_FILT_RES_TRIM and LOOP_FILT_CAP_TRIM
+        // See Table 15 and Table 16 in Section 5.7.9 of the Datasheet
+        // TODO: If inductance_uH > 1000 (1mH), we should also set LOOP_FILT_LOW_BW to 1 in TRIM3
+        let cap_trim = match actuator_config.inductance_uH {
+            0..=17 => 3,
+            18..=27 => 2,
+            28..=40 => 1,
+            _ => 0
+        };
+        // Table 16: LOOP_FILT_RES_TRIM lookup
+        // Bin Lseries into 25 μH steps: ≤25, 50, 75, …, ≥250
+        let l_idx = (actuator_config.inductance_uH.saturating_sub(13) / 25).min(9) as usize;
+        // ≤25 50  75 100 125 150 175 200 225 ≥250
+        let res_trim: u8 = match actuator_config.impedance_mOhm * 1000 {
+            0..=5   => [2, 2, 3, 3, 3, 3, 3, 3, 3, 3][l_idx],
+            6..=7   => [1, 2, 2, 3, 3, 3, 3, 3, 3, 3][l_idx],
+            8..=9   => [1, 2, 2, 2, 3, 3, 3, 3, 3, 3][l_idx],
+            10..=11 => [0, 1, 2, 2, 2, 3, 3, 3, 3, 3][l_idx],
+            12..=13 => [0, 1, 2, 2, 2, 2, 3, 3, 3, 3][l_idx],
+            14..=15 => [0, 1, 1, 2, 2, 2, 2, 3, 3, 3][l_idx],
+            16..=17 => [0, 1, 1, 2, 2, 2, 2, 2, 3, 3][l_idx],
+            18..=19 => [0, 0, 1, 1, 2, 2, 2, 2, 2, 3][l_idx],
+            20..=21 => [0, 1, 1, 2, 2, 2, 3, 3, 3, 3][l_idx],
+            22..=23 => [0, 1, 1, 2, 2, 2, 2, 3, 3, 3][l_idx],
+            24..=25 => [0, 1, 1, 2, 2, 2, 2, 3, 3, 3][l_idx],
+            26..=27 => [0, 1, 1, 2, 2, 2, 2, 2, 3, 3][l_idx],
+            28..=31 => [0, 1, 2, 2, 2, 3, 3, 3, 3, 3][l_idx],
+            32..=33 => [0, 1, 2, 2, 2, 2, 3, 3, 3, 3][l_idx],
+            34..=35 => [0, 1, 1, 2, 2, 2, 3, 3, 3, 3][l_idx],
+            36..=41 => [0, 1, 1, 2, 2, 2, 2, 3, 3, 3][l_idx],
+            42..=45 => [0, 1, 2, 2, 3, 3, 3, 3, 3, 3][l_idx],
+            _       => [0, 1, 2, 2, 2, 3, 3, 3, 3, 3][l_idx], // 46-50+
+        };
+
+        let trim4 = TRIM4::new().with_LOOP_FILT_CAP_TRIM(cap_trim).with_LOOP_FILT_RES_TRIM(res_trim);
+        self.write_register(Register::TRIM4, trim4.into()).await?;
+
+
+        // Set PID coefficients if provided
+        if actuator_config.pid_Kp.is_some() && actuator_config.pid_Ki.is_some(){
+            let pid_kp = actuator_config.pid_Kp.unwrap();
+            let pid_ki = actuator_config.pid_Kp.unwrap();
+
+            let pid_kp_h = ((pid_kp >> 7) & 0xFF) as u8;
+            let pid_kp_l = (pid_kp & 0x7F) as u8;
+            let pid_ki_h = ((pid_ki >> 7) & 0xFF) as u8;
+            let pid_ki_l = (pid_ki & 0x7F) as u8;
+
+            let top_int_cfg6_h = TOP_INT_CFG6_H::from(pid_kp_h);
+            let top_int_cfg6_l = TOP_INT_CFG6_L::from(pid_kp_l);
+            let top_int_cfg7_h = TOP_INT_CFG7_H::from(pid_ki_h);
+            let top_int_cfg7_l = TOP_INT_CFG7_L::from(pid_ki_l);
+
+            self.write_register(Register::TOP_INT_CFG6_H, top_int_cfg6_h.into()).await?;
+            self.write_register(Register::TOP_INT_CFG6_L, top_int_cfg6_l.into()).await?;
+            self.write_register(Register::TOP_INT_CFG7_H, top_int_cfg7_h.into()).await?;
+            self.write_register(Register::TOP_INT_CFG7_L, top_int_cfg7_l.into()).await?;
+        }
+
+        // TODO: additional registers may need to be set with
+        // acceleration and rapid stop enabled
 
         // Default resonant frequency
         let frequency_converted =  (1000000000 / (actuator_config.frequency_Hz as u32 * 1333)) as u16;

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -24,7 +24,10 @@ pub enum Register {
     TOP_CFG1 = 0x13,
     TOP_CFG2 = 0x14,
     TOP_CFG4 = 0x16,
-    TOP_INT_CFG1 = 0x17,
+    TOP_INT_CFG6_H = 0x1C,
+    TOP_INT_CFG6_L = 0x1D,
+    TOP_INT_CFG7_H = 0x1E,
+    TOP_INT_CFG7_L = 0x1F,
     TOP_CTL1 = 0x22,
     TOP_CTL2 = 0x23,
     SEQ_CTL1 = 0x24,
@@ -40,6 +43,7 @@ pub enum Register {
     POLARITY = 0x43,
     FRQ_PHASE_H = 0x48,
     FRQ_PHASE_L = 0x49,
+    TRIM4 = 0x60,
     TOP_CFG5 = 0x6E,
     IRQ_MASK2 = 0x83,
     SNP_MEM_0 = 0x84,
@@ -207,13 +211,28 @@ pub struct TOP_CFG4 {
     pub V2I_FACTOR_FREEZE: bool,
 }
 
-/// TOP_INT_CFG1 register (0x17)
+/// TOP_INT_CFG6_H register (0x1C)
 #[bitfield(u8)]
-pub struct TOP_INT_CFG1 {
-    #[bits(2)]
-    pub BEMF_FAULT_LIM: u8,
-    #[bits(6)]
-    __: u8,
+pub struct TOP_INT_CFG6_H {
+    pub FRQ_PID_Kp_H: u8,
+}
+
+/// TOP_INT_CFG6_L register (0x1D)
+#[bitfield(u8)]
+pub struct TOP_INT_CFG6_L {
+    pub FRQ_PID_Kp_L: u8,
+}
+
+/// TOP_INT_CFG7_H register (0x1E)
+#[bitfield(u8)]
+pub struct TOP_INT_CFG7_H {
+    pub FRQ_PID_Ki_H: u8,
+}
+
+/// TOP_INT_CFG7_L register (0x1F)
+#[bitfield(u8)]
+pub struct TOP_INT_CFG7_L {
+    pub FRQ_PID_Ki_L: u8,
 }
 
 /// TOP_CTL1 register (0x22)
@@ -315,6 +334,17 @@ pub struct FRQ_PHASE_L {
     #[bits(4)]
     __: u8,
     pub DELAY_FREEZE: bool
+}
+
+/// TRIM4 register (0x60)
+#[bitfield(u8)]
+pub struct TRIM4{
+    #[bits(2)]
+    pub LOOP_FILT_RES_TRIM: u8,
+    #[bits(2)]
+    pub LOOP_FILT_CAP_TRIM: u8,
+    #[bits(4)]
+    __: u8,
 }
 
 /// TOP_CFG5 register (0x6E)


### PR DESCRIPTION
This adds support for
- TRIM4 - which is set based on the measured inductance
- PID values - optional